### PR TITLE
fix  Dependabot update error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"
+    directory: "/trigger"
     schedule:
       interval: "daily"
     groups:


### PR DESCRIPTION
```
Dependabot couldn't find a go.mod

Dependabot requires a go.mod to evaluate your Go dependencies. It had expected to find one at the path: /go.mod.

If this isn't a Go project, you may wish to disable updates for it in the .github/dependabot.yml config file in this repo.
```