### PR TITLE
allow "iam:PassRole" action to cfn service role

### DIFF
--- a/cicd.yaml
+++ b/cicd.yaml
@@ -82,6 +82,7 @@ Resources:
                   - "iam:TagRole"
                   - "iam:UntagRole"
                   - "iam:DeleteRole"
+                  - "iam:PassRole"
 
                   # handle Service Linked Roles
                   - "iam:ListPoliciesGrantingServiceAccess"


### PR DESCRIPTION
Updating runtime of the AWS Lambda function requires this action.