### PR TITLE
responseHolidays: json.Marshal 失敗後のエラー処理後に return を追加する 

### DIFF
--- a/holidays-api/holidaysapi.go
+++ b/holidays-api/holidaysapi.go
@@ -249,6 +249,7 @@ func (h *Handler) responseHolidays(w http.ResponseWriter, holidays []holiday.Hol
 		log.Printf("failed to marshal response: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		io.WriteString(w, `{"error":"internal server error"}`)
+		return
 	}
 
 	w.Header().Set("Content-Length", strconv.Itoa(len(data)))


### PR DESCRIPTION
500エラーを書き込んだ後、`w.WriteHeader(http.StatusOK) `が呼び出されていたので、
`return` を追加しました。

```
	data, err := json.Marshal(Response{
		Holidays: res,
	})
	if err != nil {
		log.Printf("failed to marshal response: %v", err)
		w.WriteHeader(http.StatusInternalServerError)
		io.WriteString(w, `{"error":"internal server error"}`)
	}

	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
	w.WriteHeader(http.StatusOK)
	w.Write(data)
```