### PR TITLE
enable IPv6

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -31,17 +31,10 @@ Resources:
       Domain:
         CertificateArn: !Ref Certificate
         DomainName: "holidays-jp.shogo82148.com"
+        Route53:
+          HostedZoneName: "shogo82148.com."
+          IpV6: true
       CorsConfiguration: true
-
-  RecordSet:
-    Type: AWS::Route53::RecordSet
-    Properties:
-      HostedZoneName: "shogo82148.com."
-      Name: "holidays-jp.shogo82148.com"
-      Type: A
-      AliasTarget:
-        DNSName: !GetAtt ApiGatewayDomainNameV24c58e33fd3.RegionalDomainName
-        HostedZoneId: !GetAtt ApiGatewayDomainNameV24c58e33fd3.RegionalHostedZoneId
 
   Certificate:
     Type: AWS::CertificateManager::Certificate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain routing configuration with IPv6 support enabled.
  * Simplified domain setup by consolidating Route53 configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->