### PR TITLE
migrate to arm64 runners

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       id-token: write
       statuses: write

--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 jobs:
   golangci-lint:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -16,7 +16,7 @@ jobs:
           workdir: ./holidays-api/
 
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
@@ -26,7 +26,7 @@ jobs:
 
   cfn-lint:
     name: cfn-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: shogo82148/actions-cfn-lint@727428d85a506acd256788792cf402332a272ab5 # v4.60.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: Test
 on: [push, pull_request]
 jobs:
   test-updater:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Check out code
@@ -11,8 +11,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: 'updater/go.mod'
-          cache-dependency-path: 'updater/go.sum'
+          go-version-file: "updater/go.mod"
+          cache-dependency-path: "updater/go.sum"
 
       - name: Test
         run: go test -race -v -coverprofile=profile.cov ./...
@@ -27,7 +27,7 @@ jobs:
           working-directory: updater
 
   test-holidays-api:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Check out code
@@ -36,8 +36,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: 'holidays-api/go.mod'
-          cache-dependency-path: 'holidays-api/go.mod'
+          go-version-file: "holidays-api/go.mod"
+          cache-dependency-path: "holidays-api/go.mod"
 
       - name: Test
         run: go test -race -v -coverprofile=profile.cov ./...
@@ -52,7 +52,7 @@ jobs:
           working-directory: holidays-api
 
   test-update-trigger:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Check out code
@@ -61,8 +61,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: 'update-trigger/trigger/go.mod'
-          cache-dependency-path: 'update-trigger/trigger/go.mod'
+          go-version-file: "update-trigger/trigger/go.mod"
+          cache-dependency-path: "update-trigger/trigger/go.mod"
           cache: true
 
       - name: Test
@@ -78,7 +78,7 @@ jobs:
           working-directory: update-trigger/trigger
 
   finish:
-    if: 'always()'
+    if: "always()"
     needs:
       - test-updater
       - test-holidays-api

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Check out code


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD workflows updated to run on Ubuntu 24.04 (ARM) runners to improve build and deployment consistency.
  * Test, lint, update, and production deployment jobs migrated to the new runner environment; minor test cache and workflow condition quoting adjustments applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shogo82148/holidays-jp/pull/518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->