### PR TITLE
bump Go 1.27

### DIFF
--- a/holidays-api/go.mod
+++ b/holidays-api/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/holidays-jp/holidays-api
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/update-trigger/trigger/go.mod
+++ b/update-trigger/trigger/go.mod
@@ -1,6 +1,6 @@
 module trigger
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/aws/aws-lambda-go v1.54.0

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -1,5 +1,5 @@
 module github.com/shogo82148/holidays-jp/updater
 
-go 1.26.0
+go 1.27.0
 
 require golang.org/x/text v0.41.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s supported Go version to 1.27.0 across all modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->